### PR TITLE
为"不渲染工厂建筑实体"新增"同时隐藏分拣器"子选项

### DIFF
--- a/UXAssist/CHANGELOG.md
+++ b/UXAssist/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Changlog
 
+* 1.5.9
+  * `Do not render factory entities (except belts and sorters)`: Add sub-option `Hide sorters too` to also hide sorters, leaving only belts visible.
 * 1.5.8
   * `Initialize This Planet`: Fix a possible crash.
   * `Remember window position and size on last exit`: Remove a window hook that are not useful anymore.
@@ -401,6 +403,8 @@
 
 ## 更新日志
 
+* 1.5.9
+  * `不渲染工厂建筑实体(除了传送带和分拣器)`：新增子选项`同时隐藏分拣器`，可一并隐藏分拣器，只保留传送带可见。
 * 1.5.8
   * `初始化本行星`：修复可能的崩溃。
   * `记住上次退出时的窗口位置和大小`：移除不再有用的窗口钩子。

--- a/UXAssist/Common/Config/FactoryConfigProvider.cs
+++ b/UXAssist/Common/Config/FactoryConfigProvider.cs
@@ -18,6 +18,7 @@ public static class FactoryConfigProvider
     public static ConfigEntry<bool> QuickBuildAndDismantleLabsEnabled => FactoryPatch.QuickBuildAndDismantleLabsEnabled;
     public static ConfigEntry<bool> ProtectVeinsFromExhaustionEnabled => FactoryPatch.ProtectVeinsFromExhaustionEnabled;
     public static ConfigEntry<bool> DoNotRenderEntitiesEnabled => FactoryPatch.DoNotRenderEntitiesEnabled;
+    public static ConfigEntry<bool> DoNotRenderEntitiesHideSortersEnabled => FactoryPatch.DoNotRenderEntitiesHideSortersEnabled;
     public static ConfigEntry<bool> DragBuildPowerPolesEnabled => FactoryPatch.DragBuildPowerPolesEnabled;
     public static ConfigEntry<bool> DragBuildPowerPolesAlternatelyEnabled => FactoryPatch.DragBuildPowerPolesAlternatelyEnabled;
     public static ConfigEntry<bool> AutoConstructButtonEnabled => FactoryPatch.AutoConstructButtonEnabled;

--- a/UXAssist/Common/I18NKeys.cs
+++ b/UXAssist/Common/I18NKeys.cs
@@ -88,6 +88,7 @@ public static class I18NKeys
     public const string ProtectVeinsFromExhaustion = "Protect veins from exhaustion";
     public const string ProtectVeinsFromExhaustionTips = "Protect veins from exhaustion tips";
     public const string DoNotRenderFactoryEntities = "Do not render factory entities";
+    public const string HideSortersToo = "Hide sorters too";
     public const string DragBuildingPowerPolesInMaximumConnectionRange = "Drag building power poles in maximum connection range";
     public const string BuildTeslaTowerAndWirelessPowerTowerAlternately = "Build Tesla Tower and Wireless Power Tower alternately";
     public const string AutoConstructButton = "Auto-construct button";
@@ -299,6 +300,7 @@ Close this function to resume mining and pumping, usually when you have enough l
 
 """);
         I18N.Add(DoNotRenderFactoryEntities, "Do not render factory entities (except belts and sorters)", "不渲染工厂建筑实体(除了传送带和分拣器)");
+        I18N.Add(HideSortersToo, "Hide sorters too", "同时隐藏分拣器");
         I18N.Add(DragBuildingPowerPolesInMaximumConnectionRange, "Drag building power poles in maximum connection range", "拖动建造电线杆时自动使用最大连接距离间隔");
         I18N.Add(BuildTeslaTowerAndWirelessPowerTowerAlternately, "Build Tesla Tower and Wireless Power Tower alternately", "交替建造电力感应塔和无线输电塔");
         I18N.Add(AutoConstructButton, "Auto-construct button", "自动建造按钮");

--- a/UXAssist/Patches/Factory/FactoryPatch.cs
+++ b/UXAssist/Patches/Factory/FactoryPatch.cs
@@ -25,6 +25,7 @@ public static class FactoryPatch
     public static ConfigEntry<bool> QuickBuildAndDismantleLabsEnabled;
     public static ConfigEntry<bool> ProtectVeinsFromExhaustionEnabled;
     public static ConfigEntry<bool> DoNotRenderEntitiesEnabled;
+    public static ConfigEntry<bool> DoNotRenderEntitiesHideSortersEnabled;
     public static ConfigEntry<bool> DragBuildPowerPolesEnabled;
     public static ConfigEntry<bool> DragBuildPowerPolesAlternatelyEnabled;
     public static ConfigEntry<bool> AutoConstructButtonEnabled;
@@ -112,6 +113,7 @@ public static class FactoryPatch
         QuickBuildAndDismantleLabsEnabled.SettingChanged += (_, _) => ImmediateBuildPatch.QuickBuildAndDismantleLab.Enable(QuickBuildAndDismantleLabsEnabled.Value);
         ProtectVeinsFromExhaustionEnabled.SettingChanged += (_, _) => VeinProtectionPatch.ProtectVeinsFromExhaustion.Enable(ProtectVeinsFromExhaustionEnabled.Value);
         DoNotRenderEntitiesEnabled.SettingChanged += (_, _) => RenderingPatch.DoNotRenderEntities.Enable(DoNotRenderEntitiesEnabled.Value);
+        DoNotRenderEntitiesHideSortersEnabled.SettingChanged += (_, _) => RenderingPatch.DoNotRenderEntities.HideSorters = DoNotRenderEntitiesHideSortersEnabled.Value;
         DragBuildPowerPolesEnabled.SettingChanged += (_, _) => BuildToolPatch.DragBuildPowerPoles.Enable(DragBuildPowerPolesEnabled.Value);
         DragBuildPowerPolesAlternatelyEnabled.SettingChanged += (_, _) => BuildToolPatch.DragBuildPowerPoles.AlternatelyChanged();
         AutoConstructButtonEnabled.SettingChanged += (_, _) => Functions.UIFunctions.UpdateToggleAutoConstructCheckButtonVisiblility();
@@ -147,6 +149,7 @@ public static class FactoryPatch
         ImmediateBuildPatch.QuickBuildAndDismantleLab.Enable(QuickBuildAndDismantleLabsEnabled.Value);
         VeinProtectionPatch.ProtectVeinsFromExhaustion.Enable(ProtectVeinsFromExhaustionEnabled.Value);
         RenderingPatch.DoNotRenderEntities.Enable(DoNotRenderEntitiesEnabled.Value);
+        RenderingPatch.DoNotRenderEntities.HideSorters = DoNotRenderEntitiesHideSortersEnabled.Value;
         BuildToolPatch.DragBuildPowerPoles.Enable(DragBuildPowerPolesEnabled.Value);
         ImmediateBuildPatch.AutoConstructButton.Enable(AutoConstructButtonEnabled.Value);
         BeltSignalPatch.BeltSignalsForBuyOut.Enable(BeltSignalsForBuyOutEnabled.Value);

--- a/UXAssist/Patches/Factory/RenderingPatch.cs
+++ b/UXAssist/Patches/Factory/RenderingPatch.cs
@@ -19,12 +19,21 @@ internal static class RenderingPatch
 
     internal class DoNotRenderEntities : PatchImpl<DoNotRenderEntities>
     {
+        public static bool HideSorters;
+
         [HarmonyPrefix]
         [HarmonyPatch(typeof(ObjectRenderer), nameof(ObjectRenderer.Render))]
         [HarmonyPatch(typeof(DynamicRenderer), nameof(DynamicRenderer.Render))]
         private static bool ObjectRenderer_Render_Prefix()
         {
             return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(InserterRenderer), nameof(InserterRenderer.Render))]
+        private static bool InserterRenderer_Render_Prefix()
+        {
+            return !HideSorters;
         }
 
         [HarmonyPrefix]
@@ -69,7 +78,7 @@ internal static class RenderingPatch
                 new CodeInstruction(OpCodes.Ldarg_0),
                 new CodeInstruction(OpCodes.Ldloc_S, 33),
                 new CodeInstruction(OpCodes.Ldloc_S, 35),
-                Transpilers.EmitDelegate((RaycastLogic l, ColliderData[] colliderPool, int j) => l.factory.entityPool[colliderPool[j].objId].inserterId > 0),
+                Transpilers.EmitDelegate((RaycastLogic l, ColliderData[] colliderPool, int j) => !HideSorters && l.factory.entityPool[colliderPool[j].objId].inserterId > 0),
                 new CodeInstruction(OpCodes.Brfalse, branch1)
             );
             matcher.Labels.Add(branch2);

--- a/UXAssist/README.md
+++ b/UXAssist/README.md
@@ -59,6 +59,7 @@
       * Close this function to resume mining and pumping, usually when you have enough level on `Veins Utilization`
     * Do not render factory entities (except belts and sorters)
       * This also makes players click though factory entities but belts and sorters
+      * `Hide sorters too`: also hide sorters, leaving only belts (and their cargo) visible
     * Drag building power poles in maximum connection range
     * Auto-construct
       * Fly to buildings to be contructed automatically
@@ -225,6 +226,7 @@
       * 关闭此功能以恢复开采，一般是当你在`矿物利用`上有足够的等级时。
     * 不渲染工厂建筑实体(除了传送带和分拣器)
       * 这也使玩家可以点穿工厂实体直接点到传送带和分拣器
+      * `同时隐藏分拣器`：连分拣器也一并隐藏，只保留传送带（及其上的货物）可见
     * 拖动建造电线杆时自动使用最大连接距离间隔
     * 自动建造
       * 自动飞向待建造的建筑

--- a/UXAssist/UIConfigWindow.cs
+++ b/UXAssist/UIConfigWindow.cs
@@ -259,7 +259,19 @@ public static class UIConfigWindow
 
         x = 0;
         y += 36f;
-        wnd.AddCheckBox(x, y, tab2, FactoryConfigProvider.DoNotRenderEntitiesEnabled, I18NKeys.DoNotRenderFactoryEntities);
+        {
+            wnd.AddCheckBox(x, y, tab2, FactoryConfigProvider.DoNotRenderEntitiesEnabled, I18NKeys.DoNotRenderFactoryEntities);
+            y += 27f;
+            var hideSortersCheckBox = wnd.AddCheckBox(x + 20f, y, tab2, FactoryConfigProvider.DoNotRenderEntitiesHideSortersEnabled, I18NKeys.HideSortersToo, 13);
+            FactoryConfigProvider.DoNotRenderEntitiesEnabled.SettingChanged += DoNotRenderEntitiesEnabledChanged;
+            wnd.OnFree += () => { FactoryConfigProvider.DoNotRenderEntitiesEnabled.SettingChanged -= DoNotRenderEntitiesEnabledChanged; };
+            DoNotRenderEntitiesEnabledChanged(null, null);
+
+            void DoNotRenderEntitiesEnabledChanged(object o, EventArgs e)
+            {
+                hideSortersCheckBox.SetEnable(FactoryConfigProvider.DoNotRenderEntitiesEnabled.Value);
+            }
+        }
         y += 36f;
         checkBoxForMeasureTextWidth = wnd.AddCheckBox(x, y, tab2, FactoryConfigProvider.ShortcutKeysForBlueprintCopyEnabled, I18NKeys.ShortcutKeysForBlueprintCopyMode);
         wnd.AddTipsButton2(x + checkBoxForMeasureTextWidth.Width + 5f, y + 6f, tab2, I18NKeys.ShortcutKeysForBlueprintCopyMode, I18NKeys.ShortcutKeysForBlueprintCopyModeTips, "shortcut-keys-for-blueprint-copy-mode-tips");

--- a/UXAssist/UXAssist.cs
+++ b/UXAssist/UXAssist.cs
@@ -133,6 +133,8 @@ public class UXAssist : BaseUnityPlugin, IModCanSave
         VeinProtectionPatch.ProtectVeinsFromExhaustion.KeepOilSpeed = Config.Bind("Factory", "KeepOilSpeed", 1.0f, new ConfigDescription("Keep minimal oil speed (< 0.1 to disable)", new AcceptableValueRange<float>(0.0f, 10.0f))).Value;
         FactoryPatch.DoNotRenderEntitiesEnabled = Config.Bind("Factory", "DoNotRenderEntities", false,
             "Do not render factory entities");
+        FactoryPatch.DoNotRenderEntitiesHideSortersEnabled = Config.Bind("Factory", "DoNotRenderEntitiesHideSorters", false,
+            "Hide sorters too when not rendering factory entities (leaves only belts visible)");
         FactoryPatch.DragBuildPowerPolesEnabled = Config.Bind("Factory", "DragBuildPowerPoles", false,
             "Drag building power poles in maximum connection range");
         FactoryPatch.DragBuildPowerPolesAlternatelyEnabled = Config.Bind("Factory", "DragBuildPowerPolesAlternately", true,

--- a/UXAssist/UXAssist.csproj
+++ b/UXAssist/UXAssist.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BepInExPluginGuid>org.soardev.uxassist</BepInExPluginGuid>
     <Description>DSP MOD - UXAssist</Description>
-    <Version>1.5.8</Version>
+    <Version>1.5.9</Version>
     <PackageId>UXAssist</PackageId>
     <RootNamespace>UXAssist</RootNamespace>
     <PackHasChangelog>true</PackHasChangelog>


### PR DESCRIPTION
为现有的 `不渲染工厂建筑实体(除了传送带和分拣器)` 功能新增一个子选项 `同时隐藏分拣器`。在主功能启用的前提下勾选该子选项后，分拣器也会被隐藏，使画面中仅保留传送带（及其上的货物）可见。

<img width="1186" height="870" alt="image" src="https://github.com/user-attachments/assets/3d10f95f-63e3-40f9-af22-ccad8e754f51" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a sub-option to hide sorters too when factory entity rendering is disabled (leaving only belts visible).
  * Added UI improvements for controlling and filtering starmap/Milky Way info, plus new auto-cruise/auto-construct controls.
  * Cheat features for Dyson sphere shells: instant shell completion, frame removal, and multiple “illegal shell” generators.

* **Documentation**
  * Updated changelog and README (English + Chinese) to describe the sorter-hiding behavior.

* **Chores**
  * Bumped version to **1.5.9**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->